### PR TITLE
disable updates on metered connections

### DIFF
--- a/swarofi-applet.sh
+++ b/swarofi-applet.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -euo pipefail
 
+update_icon=""
+
+# skip updates check on metered connections
+skip_metered() {
+    active_connection_uuid="$(nmcli -t -m multiline -f UUID connection show --active | head -n1 | cut -c 6-)"
+    is_metered=$(nmcli -t -m multiline -f connection.metered connection show "$active_connection_uuid" | cut -c 20-)
+    if [ "$is_metered" = "yes" ]; then
+        echo "$update_icon (metered)"
+        exit 0
+    fi
+}
+
 check_updates() {
     upgrade_check_output=$(rpm-ostree upgrade --check 2>&1 || true)
     available_updates=$(echo "$upgrade_check_output" | grep 'AvailableUpdate:' || true)
@@ -15,7 +27,6 @@ check_updates() {
     if [ "$num_rpm_ostree_updates" -gt 0 ] || [ "$num_flatpak_updates" -gt 0 ]; then
         total_updates=$((num_rpm_ostree_updates + num_flatpak_updates))
 
-        update_icon=""
         message="RPM-OSTree updates: $num_rpm_ostree_updates | Flatpak updates: $num_flatpak_updates"
         echo "$update_icon $total_updates"
         echo "$message"
@@ -39,4 +50,5 @@ check_updates() {
     fi
 }
 
+skip_metered
 check_updates

--- a/swarofi-updater.sh
+++ b/swarofi-updater.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# skip updates on metered connections
+skip_metered() {
+    active_connection_uuid="$(nmcli -t -m multiline -f UUID connection show --active | head -n1 | cut -c 6-)"
+    is_metered=$(nmcli -t -m multiline -f connection.metered connection show "$active_connection_uuid" | cut -c 20-)
+    if [ "$is_metered" = "yes" ]; then
+        echo "connections is metered, skipping updates"
+        exit 0
+    fi
+}
+
 # Set variables
 dir="$(dirname "$(realpath "$0")")"
 theme="style-1"
@@ -67,6 +77,7 @@ handle_post_update() {
   esac
 }
 
+skip_metered
 check_rpmostree_updates
 check_flatpak_updates
 


### PR DESCRIPTION
With these changes, if the current network interface connection has the boolean `connection.metered` set to yes, update checks and updates are disabled.

Checking update is quite bandwidth consuming, so I thought it can useful to disable it automatically when required.

I added the same function to the two scripts, it seemed easier for integration, but it could be refractored into a new script called from the applet / updater scripts